### PR TITLE
Fix unexpected token error when used with react-native's AsyncStorage

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,10 +2,7 @@ import stringify from 'json-stringify-safe';
 
 export const makeEncryptor = transform =>
   (state, key) => {
-    if (typeof state !== 'string') {
-      state = stringify(state);
-    }
-    return transform(state);
+    return transform(stringify(state));
   };
 
 export const makeDecryptor = transform =>


### PR DESCRIPTION
I get the following error when using this package with the AsyncStorage engine:
![simulator screen shot jan 13 2017 10 01 14 pm](https://cloud.githubusercontent.com/assets/4549358/21945734/4250ffa0-d9dd-11e6-82fd-7066a03094a5.png)

This PR fixes this issue.
transform-compress does something similar: https://github.com/rt2zz/redux-persist-transform-compress/blob/master/index.js#L7
