### PR TITLE
Replacing console error with an onError option

### DIFF
--- a/src/__tests__/helpers.test.js
+++ b/src/__tests__/helpers.test.js
@@ -1,4 +1,4 @@
-import { makeEncryptor } from '../helpers';
+import { makeEncryptor, handleError } from '../helpers';
 
 describe('makeEncryptor', () => {
   it('should ensure the incoming state is a string', () => {
@@ -13,5 +13,20 @@ describe('makeEncryptor', () => {
       a: 1
     };
     expect(typeof encryptor(state, key)).toBe('string');
+  });
+});
+
+describe('errorHandler', () => {
+  it('should handle an error given a function error handler', () => {
+    const errorHandler = jest.fn();
+    handleError(errorHandler, 'error message');
+    expect(errorHandler).toHaveBeenCalledWith(
+      'error message'
+    );
+  });
+
+  it('should not throw if a non function handler is given', () => {
+    const errorHandler = 'not a function';
+    expect(() => { handleError(errorHandler, 'error message'); }).not.toThrow();
   });
 });

--- a/src/__tests__/sync.test.js
+++ b/src/__tests__/sync.test.js
@@ -1,5 +1,5 @@
 import createEncryptor from '../sync';
-global.console.error = jest.fn();
+const customErrorHandler = jest.fn();
 
 describe('sync', () => {
   it('can encrypt incoming state', () => {
@@ -28,7 +28,7 @@ describe('sync', () => {
     expect(newState).toEqual(state);
   });
 
-  it('should show a nice error message when an incorrect key is provided', () => {
+  it('should call our custom error handler when an incorrect key is provided', () => {
     const initialEncryptTransform = createEncryptor({
       secretKey: 'super-secret'
     });
@@ -38,10 +38,11 @@ describe('sync', () => {
     };
     const encryptedState = initialEncryptTransform.in(state, key);
     const encryptTransform = createEncryptor({
-      secretKey: 'different-secret'
+      secretKey: 'different-secret',
+      onError: customErrorHandler
     });
     const newState = encryptTransform.out(encryptedState, key);
-    expect(global.console.error).toHaveBeenCalledWith(
+    expect(customErrorHandler).toHaveBeenCalledWith(
       new Error(
         'Could not decrypt state. Please verify that you are using the correct secret key.'
       )

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -7,21 +7,15 @@ export const makeEncryptor = transform => (state, key) => {
   return transform(state);
 };
 
-export const makeDecryptor = transform => (state, key) => {
+export const makeDecryptor = (transform, onError) => (state, key) => {
   if (typeof state !== 'string') {
-    if (process.env.NODE_ENV !== 'production') {
-      console.error(
-        'redux-persist-transform-encrypt: expected outbound state to be a string'
-      );
-    }
+    onError && onError('redux-persist-transform-encrypt: expected outbound state to be a string');
     return state;
   }
   try {
     return transform(state);
   } catch (err) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.error(err);
-    }
+    onError && onError(err);
     return null;
   }
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -9,13 +9,19 @@ export const makeEncryptor = transform => (state, key) => {
 
 export const makeDecryptor = (transform, onError) => (state, key) => {
   if (typeof state !== 'string') {
-    onError && onError('redux-persist-transform-encrypt: expected outbound state to be a string');
+    handleError(onError, 'redux-persist-transform-encrypt: expected outbound state to be a string');
     return state;
   }
   try {
     return transform(state);
   } catch (err) {
-    onError && onError(err);
+    handleError(onError, err);
     return null;
   }
 };
+
+export const handleError = (handler, err) => {
+  if (typeof handler === 'function') {
+    handler(err);
+  }
+}

--- a/src/sync.js
+++ b/src/sync.js
@@ -6,7 +6,7 @@ import { makeEncryptor, makeDecryptor } from './helpers';
 const makeSyncEncryptor = secretKey =>
   makeEncryptor(state => AES.encrypt(state, secretKey).toString());
 
-const makeSyncDecryptor = secretKey =>
+const makeSyncDecryptor = (secretKey, onError) =>
   makeDecryptor(state => {
     const bytes = AES.decrypt(state, secretKey);
     const decryptedString = bytes.toString(CryptoJSCore.enc.Utf8);
@@ -16,10 +16,10 @@ const makeSyncDecryptor = secretKey =>
       );
     }
     return JSON.parse(decryptedString);
-  });
+}, onError);
 
 export default config => {
   const inbound = makeSyncEncryptor(config.secretKey);
-  const outbound = makeSyncDecryptor(config.secretKey);
+  const outbound = makeSyncDecryptor(config.secretKey, config.onError);
   return createTransform(inbound, outbound, config);
 };


### PR DESCRIPTION
I had a first stab a #19.

This is ultra simplistic and very simple, but it does the initial job of delegating error handling the the user.

One thing I didn't really like was the check for `process.env.NODE_ENV` which might not be available, therefore you'd potentially throw errors in production code anyway.

I've only done the `makeDecryptor` method so far, but maybe we need to add this to the `makeEncryptor` method too?