### PR TITLE
Error handler docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ import { persistReducer } from 'redux-persist'
 import createEncryptor from 'redux-persist-transform-encrypt'
 
 const encryptor = createEncryptor({
-  secretKey: 'my-super-secret-key'
+  secretKey: 'my-super-secret-key',
+  onError: function(error) { /* ... */ }
 })
 
 const reducer = persistReducer(
@@ -44,3 +45,8 @@ const reducer = persistReducer(
   baseReducer
 )
 ```
+
+### Custom Error Handling
+
+The `onError` property given to the `createEncryptor` options is an optional function that receives an `Error` object as its only parameter.
+This allows custom error handling from the application using redux-persist-transform-encrypt (sync only at the moment).

--- a/src/__tests__/helpers.test.js
+++ b/src/__tests__/helpers.test.js
@@ -19,8 +19,12 @@ describe('makeEncryptor', () => {
 describe('errorHandler', () => {
   it('should handle an error given an error handler', () => {
     const errorHandler = jest.fn()
-    handleError(errorHandler, 'error message')
-    expect(errorHandler).toHaveBeenCalledWith('error message')
+    handleError(errorHandler, new Error('error message'))
+    expect(errorHandler).toHaveBeenCalledWith(
+        new Error(
+            'error message'
+        )
+    )
   })
 
   it('should not throw if an invalid handler is given', () => {

--- a/src/__tests__/sync.test.js
+++ b/src/__tests__/sync.test.js
@@ -48,4 +48,22 @@ describe('sync', () => {
       )
     )
   })
+
+  it('should call our custom error handler when trying to decrypt something that is not a string', () => {
+    const key = 'testState'
+    const encryptedState = {
+      foo: 'bar'
+    }
+    const customErrorHandler = jest.fn()
+    const encryptTransform = createEncryptor({
+      secretKey: 'super-secret',
+      onError: customErrorHandler
+    })
+    const newState = encryptTransform.out(encryptedState, key)
+    expect(customErrorHandler).toHaveBeenCalledWith(
+      new Error(
+        'redux-persist-transform-encrypt: expected outbound state to be a string'
+      )
+    )
+  })
 })

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -17,7 +17,7 @@ export const makeDecryptor = (transform, onError) => (state, key) => {
   if (typeof state !== 'string') {
     handleError(
       onError,
-      'redux-persist-transform-encrypt: expected outbound state to be a string'
+      new Error('redux-persist-transform-encrypt: expected outbound state to be a string')
     )
     return state
   }


### PR DESCRIPTION
I'd like to get a proper release out so we can finally update our package dependencies to the right version of `redux-persist-transform-encrypt`.

Looking at #19 , it seems that the only thing missing for this release to be created and  was documentation about the error handler.

This PR brings:
- this documentation
- a small change in an error being thrown in the sync decryptor to make the interface predictable (uses error objects all the time, rather than a mix of errors and strings)
- a test covering the error thrown when attempting to decrypt something that's not a string.
