### PR TITLE
feat: add cipher for async and sync

### DIFF
--- a/src/AsyncCryptor.js
+++ b/src/AsyncCryptor.js
@@ -1,15 +1,12 @@
 import CryptoJSCore from 'crypto-js/core'
 import AES from 'crypto-js/aes'
 import Stream from 'readable-stream'
+import { makeConfig } from './helpers'
 
 export default class AsyncCryptor {
-  constructor(secretKey) {
-    const salt = CryptoJSCore.lib.WordArray.random(8)
-    const cipher = CryptoJSCore.kdf.OpenSSL.execute(secretKey, 8, 4, salt)
+  constructor(secretKey, configParam) {
     this.key = CryptoJSCore.enc.Utf8.parse(secretKey)
-    this.cryptorParams = {
-      iv: cipher.iv
-    }
+    this.cryptorParams = makeConfig(configParam)
   }
 
   encrypt(state) {

--- a/src/async.js
+++ b/src/async.js
@@ -1,6 +1,6 @@
 import { createTransform } from 'redux-persist'
 import CryptoJSCore from 'crypto-js/core'
-import { makeEncryptor, makeDecryptor } from './helpers'
+import { makeEncryptor, makeDecryptor, makeConfig } from './helpers'
 import AsyncCryptor from './AsyncCryptor'
 
 const makeAsyncEncryptor = cryptor =>
@@ -23,7 +23,9 @@ export default config => {
       'redux-persist-transform-encrypt: async support is still a work in progress.'
     )
   }
-  const asyncCryptor = new AsyncCryptor(config.secretKey)
+  config.cypher = true
+  const configParam = makeConfig(config)
+  const asyncCryptor = new AsyncCryptor(config.secretKey, configParam)
   const inbound = makeAsyncEncryptor(asyncCryptor)
   const outbound = makeAsyncDecryptor(asyncCryptor)
   return createTransform(inbound, outbound, config)

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,4 +1,5 @@
 import stringify from 'json-stringify-safe'
+import CryptoJSCore from 'crypto-js'
 
 export const handleError = (handler, err) => {
   if (typeof handler === 'function') {
@@ -29,4 +30,22 @@ export const makeDecryptor = (transform, onError) => (state, key) => {
     handleError(onError, err)
     return null
   }
+}
+
+export const makeConfig = config => {
+  if (config.cipher || config.mode || config.padding) {
+    const salt = CryptoJSCore.lib.WordArray.random(128 / 8)
+    const cipher = CryptoJSCore.kdf.OpenSSL.execute(
+      config.secretKey,
+      256 / 32,
+      128 / 32,
+      salt
+    )
+    return {
+      iv: cipher.iv,
+      mode: config.mode || CryptoJSCore.mode.ECB,
+      padding: config.padding || CryptoJSCore.pad.Pkcs7
+    }
+  }
+  return {}
 }

--- a/src/sync.js
+++ b/src/sync.js
@@ -1,15 +1,15 @@
 import { createTransform } from 'redux-persist'
 import CryptoJSCore from 'crypto-js/core'
 import AES from 'crypto-js/aes'
-import { makeEncryptor, makeDecryptor } from './helpers'
+import { makeEncryptor, makeDecryptor, makeConfig } from './helpers'
 
-const makeSyncEncryptor = secretKey =>
-  makeEncryptor(state => AES.encrypt(state, secretKey).toString())
+const makeSyncEncryptor = (secretKey, cfg) =>
+  makeEncryptor(state => AES.encrypt(state, secretKey, cfg).toString())
 
-const makeSyncDecryptor = (secretKey, onError) =>
+const makeSyncDecryptor = (secretKey, onError, cfg) =>
   makeDecryptor(state => {
     try {
-      const bytes = AES.decrypt(state, secretKey)
+      const bytes = AES.decrypt(state, secretKey, cfg)
       const decryptedString = bytes.toString(CryptoJSCore.enc.Utf8)
       return JSON.parse(decryptedString)
     } catch (err) {
@@ -20,7 +20,12 @@ const makeSyncDecryptor = (secretKey, onError) =>
   }, onError)
 
 export default config => {
-  const inbound = makeSyncEncryptor(config.secretKey)
-  const outbound = makeSyncDecryptor(config.secretKey, config.onError)
+  const configParam = makeConfig(config)
+  const inbound = makeSyncEncryptor(config.secretKey, configParam)
+  const outbound = makeSyncDecryptor(
+    config.secretKey,
+    config.onError,
+    configParam
+  )
   return createTransform(inbound, outbound, config)
 }


### PR DESCRIPTION
## Why

Currently, the async is not stable for production.
The sync librarie does not provide the possibility to use cipher.

The `crypto-js` librarie provides the ability to use cipher, padding, and mode which will improve the crypting.

## What

- This PR implement cipher, padding and / or mode for sync.
- Refactor the async part to use the same as the sync

## How

3 new parameters are now available to pass to the `createAsyncEncryptor`:

`cipher`:  CryptoJSCore.kdf.OpenSSL is implemented with default values
`mode`:  default -> Electronic Codebook block mode (from crypto-js documentation)
`padding`: default -> PKCS #5/7 padding strategy

If cipher the only true then mode and padding will be set to their default values.

## Example

```js
const encryptTransform = createEncryptor({
  secretKey: 'my-secretkey',
  cipher: true
})
```

## Notes

- Manual backwards step has been made with live version of `redux-persist-transform-encrypt` of encrypted data with default config
- **No documentation on how to use it, I do not know where and in which form do you want to put it**
- The value number are setted with mathematicals operations like it has been made in the `crypto-js` library
- 