### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
+  "main": "lib/index.js",
   "scripts": {
     "prepublishOnly": "pnpm run build",
     "format": "prettier --ignore-path .gitignore --write '**/*.+(js|json|md|ts|tsx)'",


### PR DESCRIPTION
Readded "main" reference for build systems that seem to be panicking after upgrade up to 5.

This is a possible solution for https://github.com/maxdeviant/redux-persist-transform-encrypt/issues/71 but I don't really know if it's the correct solution.

I don't know why but after upgrading to 5.0, react native on metro is failing to create a bundle on iOS.

The result is the error seen in the screenshot below.
The error states that the package.json file specified a main line of `"main": "index.js",`
However the new package.json file has switched to ESM modules, so doesn't have a main line at all.
This work adds the main line back in with a reference to the correct location at `"main": "lib/index.js",`

I do not know if this might hinder esm compatible systems in any way though so advice from someone with expertise here would be appreciated.

![IMG_1437](https://github.com/maxdeviant/redux-persist-transform-encrypt/assets/642320/cbeb61cc-e867-408b-b35a-badd9d121ad2)
