### PR TITLE
Fix #71 - Update package.json with "exports" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,13 @@
   "type": "module",
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "prepublishOnly": "pnpm run build",
     "format": "prettier --ignore-path .gitignore --write '**/*.+(js|json|md|ts|tsx)'",


### PR DESCRIPTION
Issue: [#74](https://github.com/maxdeviant/redux-persist-transform-encrypt/issues/74)

Reason: `package.json` is missing the `exports` field.
Reference: [Pure ESM package](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c#pure-esm-package)

![image](https://github.com/maxdeviant/redux-persist-transform-encrypt/assets/76950445/66419b5f-20e9-485c-a71c-e95d077612aa)
