### PR TITLE
fix: Module not found issue fix for web and native

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "5.1.1",
   "description": "Encrypt your Redux store.",
   "type": "module",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "exports": {
     "types": "./lib/index.d.ts",
     "default": "./lib/index.js"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "module": "ESNext",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "noImplicitReturns": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
This change resolves #81 #71 
Resolved an issue by updating the tsConfig.json file, adjusting the module type to resolve the error related to 'Option 'module' must be set to 'NodeNext''. For further details, refer to [this documentation](https://www.totaltypescript.com/concepts/option-module-must-be-set-to-nodenext-when-option-moduleresolution-is-set-to-nodenext).

Additionally, rectified the React Native build problem by reintroducing modules and types into package.json with the necessary export. Consequently, the error 'Cannot find module 'redux-persist-transform-encrypt' or its corresponding type declarations.ts(2307)' has been eliminated.